### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Jira와 Claude를 연결하는 Model Context Protocol (MCP) 서버입니다.
 
+<a href="https://glama.ai/mcp/servers/@SunWooBang/jira-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@SunWooBang/jira-mcp-server/badge" alt="Jira Server MCP server" />
+</a>
+
 ## 기능
 
 - **이슈 검색**: JQL을 사용하여 Jira 이슈 검색


### PR DESCRIPTION
This PR adds a badge for the [Jira MCP Server](https://glama.ai/mcp/servers/@SunWooBang/jira-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@SunWooBang/jira-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@SunWooBang/jira-mcp-server/badge" alt="Jira Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.